### PR TITLE
fix(ci): remove npm cache config for missing lockfile

### DIFF
--- a/.github/workflows/jarvis-sniper-wr-family-calibration.yml
+++ b/.github/workflows/jarvis-sniper-wr-family-calibration.yml
@@ -21,8 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: apps/jarvis-sniper/package-lock.json
 
       - name: Install dependencies
         working-directory: apps/jarvis-sniper


### PR DESCRIPTION
## Summary

The `Jarvis Sniper WR Family Calibration` workflow has failed 6 consecutive times because `actions/setup-node@v4` was configured with `cache: npm` and `cache-dependency-path: apps/jarvis-sniper/package-lock.json`, but that lockfile was never committed to the repo.

This PR removes the `cache` and `cache-dependency-path` lines from the setup-node step, keeping just `node-version: 20`, so the workflow can proceed without trying to resolve a non-existent file.

## Changes

- Removed `cache: npm` from the setup-node step
- Removed `cache-dependency-path: apps/jarvis-sniper/package-lock.json` from the setup-node step

## Test plan

- Re-run the `Jarvis Sniper WR Family Calibration` workflow after merge and confirm the setup-node step passes